### PR TITLE
Add DVAP to list of vulnerable applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 - [CryptOMG](https://github.com/SpiderLabs/CryptOMG) - CryptOMG is a configurable CTF style test bed that highlights common flaws in cryptographic implementations.
 - [CTFchallenge](https://ctfchallenge.com/) - CTFchallenge s a collection of 12 vulnerable web applications, each one has its own realistic infrastructure built over several subdomains containing vulnerabilities based on bug reports, real world experiences or vulnerabilities found in the OWASP Top 10.
 - [Damn Vulnerable Cloud Application](https://github.com/m6a-UdS/dvca.git) - Damn Vulnerable Cloud Application
+- [DVAP (Damn Vulnerable AI Platform)](https://github.com/sonuoffsec/DVAP) - Open-source AI security training platform featuring vulnerable AI agents, prompt injection labs, MCP attacks, RAG exploitation, agent security, tool poisoning, and AI red-team exercises.
 - [Damn Vulnerable Node Application(DVNA)](https://github.com/appsecco/dvna) - Damn Vulnerable NodeJS Application
 - [Damn Vulnerable Web App (DVWA)](http://www.dvwa.co.uk/) - Damn Vulnerablbe Web Application
 - [Damn Vulnerable Web Services (DVWS)](https://github.com/snoopysecurity/dvws) -


### PR DESCRIPTION
This PR adds DVAP (Damn Vulnerable AI Platform) to the Awesome Vulnerable list.

DVAP is an open-source vulnerable-by-design AI security training platform covering prompt injection, MCP attacks, RAG exploitation, agent security, tool poisoning, and AI red teaming.

Repository:
https://github.com/sonuoffsec/DVAP